### PR TITLE
feat: make the sequencer the sole governer by default

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -64,7 +64,6 @@ import (
 	paramstypes "github.com/cosmos/cosmos-sdk/x/params/types"
 	paramproposal "github.com/cosmos/cosmos-sdk/x/params/types/proposal"
 
-	stakingkeeper "github.com/cosmos/cosmos-sdk/x/staking/keeper"
 	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
 	"github.com/cosmos/cosmos-sdk/x/upgrade"
 	upgradeclient "github.com/cosmos/cosmos-sdk/x/upgrade/client"
@@ -97,6 +96,7 @@ import (
 	_ "github.com/cosmos/cosmos-sdk/client/docs/statik"
 
 	staking "github.com/dymensionxyz/dymension-rdk/x/staking"
+	stakingkeeper "github.com/dymensionxyz/dymension-rdk/x/staking/keeper"
 
 	"github.com/dymensionxyz/dymension-rdk/x/sequencers"
 	seqkeeper "github.com/dymensionxyz/dymension-rdk/x/sequencers/keeper"
@@ -351,9 +351,7 @@ func NewRollapp(
 
 	// register the staking hooks
 	// NOTE: stakingKeeper above is passed by reference, so that it will contain these hooks
-	app.StakingKeeper = *stakingKeeper.SetHooks(
-		stakingtypes.NewMultiStakingHooks(app.DistrKeeper.Hooks()),
-	)
+	app.StakingKeeper = *stakingKeeper.SetHooks(app.DistrKeeper.Hooks())
 
 	app.EpochsKeeper.SetHooks(
 		epochstypes.NewMultiEpochHooks(

--- a/app/export.go
+++ b/app/export.go
@@ -33,7 +33,7 @@ func (app *App) ExportAppStateAndValidators(
 		return servertypes.ExportedApp{}, err
 	}
 
-	validators, err := staking.WriteValidators(ctx, app.StakingKeeper)
+	validators, err := staking.WriteValidators(ctx, app.StakingKeeper.Keeper)
 	if err != nil {
 		return servertypes.ExportedApp{}, err
 	}

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.19
 require (
 	github.com/cosmos/cosmos-sdk v0.46.13
 	github.com/cosmos/ibc-go/v6 v6.1.1
-	github.com/dymensionxyz/dymension-rdk v0.4.0-rc4
+	github.com/dymensionxyz/dymension-rdk v0.4.0-rc1.0.20230809150756-11f18b635f36
 	github.com/dymensionxyz/dymint v0.5.0-rc4
 	github.com/gorilla/mux v1.8.0
 	github.com/rakyll/statik v0.1.7

--- a/go.sum
+++ b/go.sum
@@ -480,8 +480,8 @@ github.com/dymensionxyz/cosmosclient v0.4.0-beta h1:IWyEEdvJ60n/v/DGNelD0n23lS6E
 github.com/dymensionxyz/cosmosclient v0.4.0-beta/go.mod h1:3y64ecWDzhnd0sSYZfaL4QpwgK0b0j6LFLVRGdygg+o=
 github.com/dymensionxyz/dymension v0.2.0-beta.0.20230607115558-745644a96ea6 h1:dnriGXmMdYEiF/8lMrj+PDlN1vyQc6zgs/ZHL67eoyI=
 github.com/dymensionxyz/dymension v0.2.0-beta.0.20230607115558-745644a96ea6/go.mod h1:rDkVuF+DxBDi5tTgVHFk1D2xpqf8bOccs6aB1wTOvP0=
-github.com/dymensionxyz/dymension-rdk v0.4.0-rc4 h1:EiJqXDJzFURJJ4sBQQznUTa7FWg8jqZchHjcM/i4brU=
-github.com/dymensionxyz/dymension-rdk v0.4.0-rc4/go.mod h1:WnVuK8nbDkuHFfTZfboIEZBu49h2c/3chJC7TKSJc5c=
+github.com/dymensionxyz/dymension-rdk v0.4.0-rc1.0.20230809150756-11f18b635f36 h1:OWhEoH+2SI+1e5+XGlWUWjxh9Sw8s6fQm76vJTKcnJs=
+github.com/dymensionxyz/dymension-rdk v0.4.0-rc1.0.20230809150756-11f18b635f36/go.mod h1:7jBUHXPco3E2GT6oAkzARnLfqg6a6IjmoUSFPOArrTg=
 github.com/dymensionxyz/dymint v0.5.0-rc4 h1:wx6Be6O8rtOf+klDAMwv+tbfiJiyKEqiK69f9114KoE=
 github.com/dymensionxyz/dymint v0.5.0-rc4/go.mod h1:wwYbbeqhzANMDbpAaZLTTpypDvfQmt0+WuIiaT3xWQk=
 github.com/dymensionxyz/ibc-go/v6 v6.0.0-rc0.0.20230619115257-1a1038e16d71 h1:T04fab8CTYu+FR6mAC/nYB78WtHM4YsI99ikrYydncM=

--- a/scripts/init.sh
+++ b/scripts/init.sh
@@ -20,6 +20,8 @@ set_denom() {
 # Assuming 1,000,000 tokens
 #half is staked
 TOKEN_AMOUNT="1000000000000$DENOM"
+STAKING_AMOUNT="500000000000$DENOM"
+
 
 CONFIG_DIRECTORY="$ROLLAPP_CHAIN_DIR/config"
 GENESIS_FILE="$CONFIG_DIRECTORY/genesis.json"
@@ -62,4 +64,13 @@ set_denom "$DENOM"
 $EXECUTABLE keys add "$KEY_NAME_ROLLAPP" --keyring-backend test
 $EXECUTABLE add-genesis-account "$KEY_NAME_ROLLAPP" "$TOKEN_AMOUNT" --keyring-backend test
 $EXECUTABLE gentx_seq --pubkey "$($EXECUTABLE dymint show-sequencer)" --from "$KEY_NAME_ROLLAPP"
+
+echo "Do you want to include staker on genesis? (Y/n) "
+read -r answer
+if [ ! "$answer" != "${answer#[Nn]}" ] ;then
+  $EXECUTABLE gentx "$KEY_NAME_ROLLAPP" "$STAKING_AMOUNT" --chain-id "$ROLLAPP_CHAIN_ID" --keyring-backend test --home "$ROLLAPP_CHAIN_DIR"
+  $EXECUTABLE collect-gentxs --home "$ROLLAPP_CHAIN_DIR"
+fi
+
+
 $EXECUTABLE validate-genesis


### PR DESCRIPTION
update `app.go` to use the RDK's staking keeper, that allows registering stakers on genesis