### PR TITLE
README: a notice to make sure `jq` is installed

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ export DENOM="urax"
 export MONIKER="$ROLLAPP_CHAIN_ID-sequencer"
 ```
 
-And initialize the rollapp:
+And initialize the rollapp (make sure [jq](https://jqlang.github.io/jq/) is installed before run):
 
 ```shell
 sh scripts/init.sh


### PR DESCRIPTION
A notice added to make sure that [jq](https://jqlang.github.io/jq/) is installed before run `sh scripts/init.sh`