### PR TITLE
fixed broken link to building Rollaps documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ It uses Cosmos-SDK's [simapp](https://github.com/cosmos/cosmos-sdk/tree/main/sim
 
 ## Quick guide
 
-Get started with [building RollApps](https://docs.dymension.xyz/develop/get-started/setup)
+Get started with [building RollApps](https://docs.dymension.xyz/build/overview/)
 
 ## Installing / Getting started
 


### PR DESCRIPTION
**Describe the bug**
The link to the docs is broken in the [Readme file](https://github.com/dymensionxyz/rollapp/blob/main/README.md)

**To Reproduce**
Steps to reproduce the behavior:
1. Go to [Docs](https://github.com/dymensionxyz/rollapp/blob/main/README.md)
2. Scroll down to line 24 [ln 24](Get started with [building RollApps](https://docs.dymension.xyz/develop/get-started/setup))
3. See error:
`Get started with [building RollApps](https://docs.dymension.xyz/develop/get-started/setup)`

**Expected behavior**
Should point to [building Rollaps](https://docs.dymension.xyz/build/overview)

**Screenshots**
Here's the hyperlink to the pointed webpage currently 
![image](https://github.com/dymensionxyz/rollapp/assets/43913734/7f40a624-d439-482d-8c79-480df8659eee)
